### PR TITLE
Relax deps for Rails 6

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 appraise '4.2' do
+  gem 'pg', '~> 0.15'
   gem 'activerecord', '~> 4.2'
 end
 
@@ -14,4 +15,11 @@ end
 
 appraise '5.2' do
   gem 'activerecord', '~> 5.2'
+end
+
+appraise '6.0.0.beta1' do
+  gem 'activerecord', '6.0.0.beta1'
+  # ISSUE: https://github.com/pat/combustion/issues/96
+  gem "combustion", github: "pat/combustion",
+                    ref: "3c4bc97e0ff7870c1589bcdbc1c41b3966932eb6"
 end

--- a/activerecord-postgres_enum.gemspec
+++ b/activerecord-postgres_enum.gemspec
@@ -30,11 +30,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", ">= 4.2.0", "<= 5.2"
-  spec.add_runtime_dependency "pg", "< 1"
+  spec.add_runtime_dependency "activerecord", ">= 4.2.0"
+  spec.add_runtime_dependency "pg"
 
   spec.add_development_dependency "appraisal", "~> 2.2"
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "combustion", '~> 1.0'
   spec.add_development_dependency "pry-byebug", "~> 3"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/active_record/postgres_enum/postgresql_adapter.rb
+++ b/lib/active_record/postgres_enum/postgresql_adapter.rb
@@ -36,6 +36,8 @@ module ActiveRecord
       end
 
       def rename_enum_value(name, existing_value, new_value)
+        raise "Renaming enum values is only supported in PostgreSQL 10.0+" unless rename_enum_value_supported?
+
         execute "ALTER TYPE #{name} RENAME VALUE '#{existing_value}' TO '#{new_value}'"
       end
 
@@ -47,6 +49,10 @@ module ActiveRecord
         spec = super(column, types)
         spec[:enum_name] = column.cast_type.enum_name.inspect if column.type == :enum
         spec
+      end
+
+      def rename_enum_value_supported?
+        ActiveRecord::Base.connection.send(:postgresql_version) >= 100_000
       end
     end
   end


### PR DESCRIPTION
Looks like not changes required.

Also, added an exception when `rename_enum_value` is used with unsupported pg version.