### PR TITLE
Fix schema_dumper for Rails 5/6

### DIFF
--- a/lib/active_record/postgres_enum.rb
+++ b/lib/active_record/postgres_enum.rb
@@ -15,7 +15,20 @@ ActiveSupport.on_load(:active_record) do
   require "active_record/postgres_enum/extensions"
 
   ActiveRecord::SchemaDumper.prepend ActiveRecord::PostgresEnum::SchemaDumper
+
   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend ActiveRecord::PostgresEnum::PostgreSQLAdapter
+
+  if defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::ColumnDumper)
+    ActiveRecord::ConnectionAdapters::PostgreSQL::ColumnDumper.prepend(
+      ActiveRecord::PostgresEnum::PostgreSQLAdapter::ColumnDumperExt
+    )
+  end
+
+  if defined?(ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper)
+    ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper.prepend(
+      ActiveRecord::PostgresEnum::PostgreSQLAdapter::SchemaDumperExt
+    )
+  end
 
   ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:enum] = {
     name: 'enum'

--- a/lib/active_record/postgres_enum/postgresql_adapter.rb
+++ b/lib/active_record/postgres_enum/postgresql_adapter.rb
@@ -3,6 +3,26 @@
 module ActiveRecord
   module PostgresEnum
     module PostgreSQLAdapter
+      # For Rails >= 5.2
+      # https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+      module SchemaDumperExt
+        def prepare_column_options(column)
+          spec = super
+          spec[:enum_name] = column.sql_type.inspect if column.type == :enum
+          spec
+        end
+      end
+
+      # For Rails <5.2
+      # https://github.com/rails/rails/blob/5-1-stable/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+      module ColumnDumperExt
+        def prepare_column_options(column)
+          spec = super
+          spec[:enum_name] = column.sql_type.inspect if column.type == :enum
+          spec
+        end
+      end
+
       DEFINED_ENUMS_QUERY = <<~SQL
         SELECT t.OID, t.typname, t.typtype, array_agg(e.enumlabel) as enumlabels
         FROM pg_type t


### PR DESCRIPTION
Rails 6 has been tested in the app.

Not sure how add specs for these though.