### PR TITLE
Make dump code style consistent with Rails

### DIFF
--- a/lib/active_record/postgres_enum/schema_dumper.rb
+++ b/lib/active_record/postgres_enum/schema_dumper.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
         @connection.enums.each do |name, values|
           values = values.map(&:inspect).join(', ')
-          statements << "  create_enum('#{name}', [#{values}])"
+          statements << "  create_enum #{name.inspect}, [#{values}]"
         end
 
         stream.puts statements.join("\n")


### PR DESCRIPTION
Before:

```ruby
ActiveRecord::Schema.define(version: 2019_01_14_215416) do
  create_enum('visibility_type', ["private", "public"])

  create_table "cities", id: :serial, force: :cascade do |t|
    t.string "name", null: false
    t.enum "visibility", default: "public", null: false, enum_name: "visibility_type"
  end
end
```

After:

```ruby
ActiveRecord::Schema.define(version: 2019_01_14_215416) do
  create_enum :visibility_type, ["private", "public"]

  create_table "cities", id: :serial, force: :cascade do |t|
    t.string "name", null: false
    t.enum "visibility", default: "public", null: false, enum_name: "visibility_type"
  end
end
```
