### PR TITLE
Support complex enum values and ordering

### DIFF
--- a/lib/active_record/postgres_enum/schema_dumper.rb
+++ b/lib/active_record/postgres_enum/schema_dumper.rb
@@ -16,8 +16,8 @@ module ActiveRecord
         statements = []
 
         @connection.enums.each do |name, values|
-          values = values.map(&:inspect).join(', ')
-          statements << "  create_enum #{name.inspect}, [#{values}]"
+          values = values.map { |v| "    #{v.inspect}," }.join("\n")
+          statements << "  create_enum #{name.inspect}, [\n#{values}\n  ]"
         end
 
         stream.puts statements.join("\n")

--- a/spec/active_record/migrations_spec.rb
+++ b/spec/active_record/migrations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ActiveRecord::PostgresEnum::CommandRecorder do
 
     migration.migrate(:up)
 
-    expect(connection.enums[:genre]).to eq %w[comedy drama]
+    expect(connection.enums[:genre]).to eq %w[drama comedy]
 
     migration.migrate(:down)
 
@@ -25,12 +25,12 @@ RSpec.describe ActiveRecord::PostgresEnum::CommandRecorder do
     migration.migrate(:up)
 
     expect(connection.enums[:genre]).to be_nil
-    expect(connection.enums[:style]).to eq %w[comedy drama]
+    expect(connection.enums[:style]).to eq %w[drama comedy]
 
     migration.migrate(:down)
 
     expect(connection.enums[:style]).to be_nil
-    expect(connection.enums[:genre]).to eq %w[comedy drama]
+    expect(connection.enums[:genre]).to eq %w[drama comedy]
   end
 
   it "reverts rename_enum_value" do
@@ -40,10 +40,10 @@ RSpec.describe ActiveRecord::PostgresEnum::CommandRecorder do
 
     migration.migrate(:up)
 
-    expect(connection.enums[:genre]).to eq %w[comedy thriller]
+    expect(connection.enums[:genre]).to eq %w[thriller comedy]
 
     migration.migrate(:down)
 
-    expect(connection.enums[:genre]).to eq %w[comedy drama]
+    expect(connection.enums[:genre]).to eq %w[drama comedy]
   end
 end

--- a/spec/active_record/postgres_enum_spec.rb
+++ b/spec/active_record/postgres_enum_spec.rb
@@ -35,6 +35,36 @@ RSpec.describe ActiveRecord::PostgresEnum do
       expect(connection.enums[:foo]).to eq %w(a1 a2 a3)
     end
 
+    it "adds an enum value after a given value" do
+      expect { connection.add_enum_value(:foo, "a3", after: "a1") }.to_not raise_error
+      expect(connection.enums[:foo]).to eq %w(a1 a3 a2)
+    end
+
+    it "adds an enum value before a given value" do
+      expect { connection.add_enum_value(:foo, "a3", before: "a1") }.to_not raise_error
+      expect(connection.enums[:foo]).to eq %w(a3 a1 a2)
+    end
+
+    it "adds an enum value with a space" do
+      expect { connection.add_enum_value(:foo, "a 3") }.to_not raise_error
+      expect(connection.enums[:foo]).to eq ["a1", "a2", "a 3"]
+    end
+
+    it "adds an enum value with a comma" do
+      expect { connection.add_enum_value(:foo, "a,3") }.to_not raise_error
+      expect(connection.enums[:foo]).to eq ["a1", "a2", "a,3"]
+    end
+
+    it "adds an enum value with a single quote" do
+      expect { connection.add_enum_value(:foo, "a'3") }.to_not raise_error
+      expect(connection.enums[:foo]).to eq ["a1", "a2", "a'3"]
+    end
+
+    it "adds an enum value with a double quote" do
+      expect { connection.add_enum_value(:foo, 'a"3') }.to_not raise_error
+      expect(connection.enums[:foo]).to eq ["a1", "a2", 'a"3']
+    end
+
     it "renames an enum value" do
       expect { connection.rename_enum_value(:foo, "a2", "b2") }.to_not raise_error
       expect(connection.enums[:foo]).to eq %w(a1 b2)


### PR DESCRIPTION
- Quote enum values (to allow values with spaces, quotes, etc)
- Preserve enum value ordering
- Enhance add_enum_value to allow inserting values before or after other values
- Dump to db/schema.rb with a one value per line format, for readable diffs

`#quote` comes from [ActiveRecord::ConnectionAdapters::Quoting](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Quoting.html#method-i-quote)

You can `ORDER BY` an enum column, so being able to control the order can be quite useful.