### PR TITLE
Fix Ruby 2.7 keyword arg deprecation warning

### DIFF
--- a/lib/active_record/postgres_enum/extensions.rb
+++ b/lib/active_record/postgres_enum/extensions.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
           def initialize(options = {})
             @enum_name = options.delete(:enum_name).to_sym
-            super
+            super(**options)
           end
         end
 


### PR DESCRIPTION
Reference: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

The ActiveRecord master branch receives these arguments as kw args, so I think this fix should be good 👍 https://github.com/rails/rails/blob/master/activemodel/lib/active_model/type/value.rb#L8