### PR TITLE
Add ability to remove value from enum type

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ To add a value into existing enum:
 add_enum_value :mood, "pensive"
 ```
 
+To remove a value from existing enum:
+
+```ruby
+remove_enum_value :mood, "pensive"
+```
+
 To add a new enum column to an existing table:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ add_enum_value :mood, "pensive"
 
 To remove a value from existing enum:
 
+> :warning: Make sure that value is not used anywhere in the database.
+
 ```ruby
 remove_enum_value :mood, "pensive"
 ```

--- a/lib/active_record/postgres_enum/postgresql_adapter.rb
+++ b/lib/active_record/postgres_enum/postgresql_adapter.rb
@@ -64,6 +64,11 @@ module ActiveRecord
         end
         execute sql
       end
+      
+      def remove_enum_value(name, value)
+        sql = "DELETE FROM pg_enum WHERE enumlabel=#{quote value} AND enumtypid=(SELECT oid FROM pg_type WHERE typname='#{name}')"
+        execute sql
+      end
 
       def rename_enum_value(name, existing_value, new_value)
         raise "Renaming enum values is only supported in PostgreSQL 10.0+" unless rename_enum_value_supported?

--- a/lib/active_record/postgres_enum/postgresql_adapter.rb
+++ b/lib/active_record/postgres_enum/postgresql_adapter.rb
@@ -64,9 +64,13 @@ module ActiveRecord
         end
         execute sql
       end
-      
+
       def remove_enum_value(name, value)
-        sql = "DELETE FROM pg_enum WHERE enumlabel=#{quote value} AND enumtypid=(SELECT oid FROM pg_type WHERE typname='#{name}')"
+        sql = %{
+          DELETE FROM pg_enum
+          WHERE enumlabel=#{quote value}
+          AND enumtypid=(SELECT oid FROM pg_type WHERE typname='#{name}')
+        }
         execute sql
       end
 

--- a/spec/active_record/postgres_enum_spec.rb
+++ b/spec/active_record/postgres_enum_spec.rb
@@ -73,25 +73,25 @@ RSpec.describe ActiveRecord::PostgresEnum do
     it "removes an enum value with a space" do
       expect { connection.add_enum_value(:foo, "a 3") }.to_not raise_error
       expect { connection.remove_enum_value(:foo, "a 3") }.to_not raise_error
-      expect(connection.enums[:foo]).to eq ["a1", "a2"]
+      expect(connection.enums[:foo]).to eq %w(a1 a2)
     end
 
     it "removes an enum value with a comma" do
       expect { connection.add_enum_value(:foo, "a,3") }.to_not raise_error
       expect { connection.remove_enum_value(:foo, "a,3") }.to_not raise_error
-      expect(connection.enums[:foo]).to eq ["a1", "a2"]
+      expect(connection.enums[:foo]).to eq %w(a1 a2)
     end
 
     it "removes an enum value with a single quote" do
       expect { connection.add_enum_value(:foo, "a'3") }.to_not raise_error
       expect { connection.remove_enum_value(:foo, "a'3") }.to_not raise_error
-      expect(connection.enums[:foo]).to eq ["a1", "a2"]
+      expect(connection.enums[:foo]).to eq %w(a1 a2)
     end
 
     it "removes an enum value with a double quote" do
       expect { connection.add_enum_value(:foo, "a\"3") }.to_not raise_error
       expect { connection.remove_enum_value(:foo, "a\"3") }.to_not raise_error
-      expect(connection.enums[:foo]).to eq ["a1", "a2"]
+      expect(connection.enums[:foo]).to eq %w(a1 a2)
     end
 
     it "renames an enum value" do

--- a/spec/active_record/postgres_enum_spec.rb
+++ b/spec/active_record/postgres_enum_spec.rb
@@ -65,6 +65,35 @@ RSpec.describe ActiveRecord::PostgresEnum do
       expect(connection.enums[:foo]).to eq ["a1", "a2", 'a"3']
     end
 
+    it "removes an enum value" do
+      expect { connection.remove_enum_value(:foo, "a1") }.to_not raise_error
+      expect(connection.enums[:foo]).to eq %w(a2)
+    end
+
+    it "removes an enum value with a space" do
+      expect { connection.add_enum_value(:foo, "a 3") }.to_not raise_error
+      expect { connection.remove_enum_value(:foo, "a 3") }.to_not raise_error
+      expect(connection.enums[:foo]).to eq ["a1", "a2"]
+    end
+
+    it "removes an enum value with a comma" do
+      expect { connection.add_enum_value(:foo, "a,3") }.to_not raise_error
+      expect { connection.remove_enum_value(:foo, "a,3") }.to_not raise_error
+      expect(connection.enums[:foo]).to eq ["a1", "a2"]
+    end
+
+    it "removes an enum value with a single quote" do
+      expect { connection.add_enum_value(:foo, "a'3") }.to_not raise_error
+      expect { connection.remove_enum_value(:foo, "a'3") }.to_not raise_error
+      expect(connection.enums[:foo]).to eq ["a1", "a2"]
+    end
+
+    it "removes an enum value with a double quote" do
+      expect { connection.add_enum_value(:foo, "a\"3") }.to_not raise_error
+      expect { connection.remove_enum_value(:foo, "a\"3") }.to_not raise_error
+      expect(connection.enums[:foo]).to eq ["a1", "a2"]
+    end
+
     it "renames an enum value" do
       expect { connection.rename_enum_value(:foo, "a2", "b2") }.to_not raise_error
       expect(connection.enums[:foo]).to eq %w(a1 b2)


### PR DESCRIPTION
In order to make migration (which is adding new values to an enum type) reversible, I decided to add the ability to remove value from enum.


- [x] I have added tests
- [x] I have made corresponding changes to the documentation
