### PR TITLE
Add :force option to create_enum

### DIFF
--- a/lib/active_record/postgres_enum/postgresql_adapter.rb
+++ b/lib/active_record/postgres_enum/postgresql_adapter.rb
@@ -42,8 +42,10 @@ module ActiveRecord
         end
       end
 
-      def create_enum(name, values, if_not_exists: nil)
+      def create_enum(name, values, force: false, if_not_exists: nil)
         return if if_not_exists && enums.include?(name.to_sym)
+
+        drop_enum(name, cascade: force == :cascade, if_exists: true) if force
 
         values = values.map { |v| quote v }
         execute "CREATE TYPE #{name} AS ENUM (#{values.join(', ')})"

--- a/lib/active_record/postgres_enum/schema_dumper.rb
+++ b/lib/active_record/postgres_enum/schema_dumper.rb
@@ -20,7 +20,7 @@ module ActiveRecord
           statements << "  create_enum #{name.inspect}, [\n#{values}\n  ], force: :cascade"
         end
 
-        stream.puts statements.join("\n")
+        stream.puts statements.join("\n\n")
         stream.puts
       end
     end

--- a/lib/active_record/postgres_enum/schema_dumper.rb
+++ b/lib/active_record/postgres_enum/schema_dumper.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
         @connection.enums.each do |name, values|
           values = values.map { |v| "    #{v.inspect}," }.join("\n")
-          statements << "  create_enum #{name.inspect}, [\n#{values}\n  ]"
+          statements << "  create_enum #{name.inspect}, [\n#{values}\n  ], force: :cascade"
         end
 
         stream.puts statements.join("\n")

--- a/spec/active_record/postgres_enum_spec.rb
+++ b/spec/active_record/postgres_enum_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe ActiveRecord::PostgresEnum do
       expect { connection.create_enum(:foo, %w(a1 a2), if_not_exists: true) }.not_to raise_error
     end
 
+    it "does not change the enum options if it exists" do
+      expect { connection.create_enum(:foo, %w(b1 b2), if_not_exists: true) }.not_to raise_error
+      expect(connection.enums[:foo]).to eq %w(a1 a2)
+    end
+
     it "fails create an existing enum" do
       expect { connection.create_enum(:foo, %w(a1 a2)) }.to raise_error StandardError
     end


### PR DESCRIPTION
# Context

This PR adds a new `:force` option to `create_enum` that's intended to follow what `create_table` does in ActiveRecord. Notably, this work fixes #22 and allows the rake `db:setup` task to succeed. However, existing _schema.rb_ files need to be updated to take advantage of the new option. Running `rake db:schema:dump` should be enough to update existing `create_enum` calls. Newly run migrations will have `:force` set to `:cascade` by default.

## Related tickets

#22 db:setup fails with ActiveRecord::StatementInvalid: PG::DuplicateObject

# What's inside

There is a new option to `create_enum`: `:force`.

When set to any truthy value, `create_enum` will be preceded by a `drop_enum` call. This call will do an `IF EXISTS` check, but will not cascade default unless the `:force` value is set to `:cascade`. As far as I can tell, this mirrors what ActiveRecord does for `create_table`.

Additionally, I've updated the schema dumper to set `force: :cascade` for any new entries to the _schema.rb_. I believe this matches how ActiveRecord handles newly created tables and, as such, matches what many developers expect. But, I'm not an ActiveRecord internals expert so I may have misinterpreted some of the existing code.

I should note that I couldn't figure out when `CommandRecorder` is invoked, so I didn't modify it. Please provide guidance there if changes are necessary.

# Checklist:

- [X] I have added tests

I've added tests for code that already had tests. There were no tests for the schema dumper and I didn't know how to get started with that, so there are no new tests for this functionality either.

- [ ] I have made corresponding changes to the documentation

I don't think any documentation is warranted, but please let me know if you'd like something.