### PR TITLE
fix: don't use original  method from rails 7

### DIFF
--- a/lib/active_record/postgres_enum/schema_dumper.rb
+++ b/lib/active_record/postgres_enum/schema_dumper.rb
@@ -4,10 +4,12 @@ module ActiveRecord
   module PostgresEnum
     # provide support for writing out the 'create_enum' calls in schema.rb
     module SchemaDumper
-      def tables(stream)
-        types(stream)
+      unless ActiveRecord::PostgresEnum.rails_7?
+        def tables(stream)
+          types(stream)
 
-        super
+          super
+        end
       end
 
       private
@@ -25,10 +27,12 @@ module ActiveRecord
         end
       end
 
-      def prepare_column_options(column)
-        spec = super
-        spec[:enum_type] ||= "\"#{column.sql_type}\"" if column.enum?
-        spec
+      unless ActiveRecord::PostgresEnum.rails_7?
+        def prepare_column_options(column)
+          spec = super
+          spec[:enum_type] ||= "\"#{column.sql_type}\"" if column.enum?
+          spec
+        end
       end
     end
   end


### PR DESCRIPTION
# Context

Rails 7 `types` method returns an array of arrays instead of a hash. It is inefficient for most cases.

## Related tickets

#55 

# What's inside

<!--
List of features and changes (or highlights) (from the code perspective)
The purpose of this list is to track the progress if it's WIP (use checkboxes)
and to emphasize the critical parts (which you'd like to pay reviewers attention to)
-->
- [x] Patch schema dumper for Rails 7 too
