### PR TITLE
Fix rake task name for schema load in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ create_table :person do
 end
 ```
 
-Running the above will create a table :person, with a column :person_mood of type :mood. This will also be saved on schema.rb so that `rake schema:load` works as expected.
+Running the above will create a table :person, with a column :person_mood of type :mood. This will also be saved on schema.rb so that `rake db:schema:load` works as expected.
 
 To drop an existing enum:
 


### PR DESCRIPTION
# Context

There is no such rake task `schema:load`:

```
$ RAILS_ENV=test rake schema:load
rake aborted!
Don't know how to build task 'schema:load' (See the list of available tasks with `rake --tasks`)
Did you mean?  db:schema:load

(See full trace by running task with --trace)
```

## Related tickets



# What's inside

- [x] Fixed README

# Checklist:
