### PR TITLE
Prevent empty lines in schema.rb if db has no enums

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,9 +2,9 @@ name: Ruby
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ '**' ]
+    branches: ["**"]
 
 jobs:
   test:
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0' ]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
     env:
       RUBY_IMAGE: ${{ matrix.ruby }}
     name: Ruby ${{ matrix.ruby }}
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: ${{ matrix.ruby }}
       - name: Install dependencies
         run: |
           gem install dip

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,1 @@
+ruby_version: 2.7

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,1 +1,0 @@
-ruby_version: 2.6

--- a/Appraisals
+++ b/Appraisals
@@ -10,8 +10,6 @@ appraise "rails-6" do
   gem "rails", "~> 6.0"
 end
 
-if RUBY_VERSION >= "2.7"
-  appraise "rails-7" do
-    gem "rails", "~> 7.0"
-  end
+appraise "rails-7" do
+  gem "rails", "~> 7.0"
 end

--- a/activerecord-postgres_enum.gemspec
+++ b/activerecord-postgres_enum.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.add_runtime_dependency "activerecord", ">= 5.2"
   spec.add_runtime_dependency "pg"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ruby:
-    image: ruby:${RUBY_IMAGE:-2.7}-buster
+    image: ruby:${RUBY_IMAGE:-2.7}
     environment:
       - HISTFILE=/app/tmp/.bash_history
       - BUNDLE_PATH=/bundle

--- a/lib/active_record/postgres_enum/column.rb
+++ b/lib/active_record/postgres_enum/column.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# frozen_string_literal: true
-
 module ActiveRecord
   module PostgresEnum
     module Column

--- a/lib/active_record/postgres_enum/schema_dumper.rb
+++ b/lib/active_record/postgres_enum/schema_dumper.rb
@@ -22,8 +22,12 @@ module ActiveRecord
             statements << "  create_enum #{name.inspect}, [\n#{values}\n  ], force: :cascade"
           end
 
-          stream.puts statements.join("\n\n")
-          stream.puts
+          # Check if there any enum types to dump - otherwise don't output
+          # anything to prevent empty lines in schema.rb
+          if statements.any?
+            stream.puts statements.join("\n\n")
+            stream.puts
+          end
         end
       end
 

--- a/spec/support/migrations_helper.rb
+++ b/spec/support/migrations_helper.rb
@@ -2,7 +2,7 @@
 
 module MigrationsHelper
   def build_migration(&block)
-    Class.new(Rails::VERSION::MAJOR < 5 ? ActiveRecord::Migration : ActiveRecord::Migration::Current) do
+    Class.new((Rails::VERSION::MAJOR < 5) ? ActiveRecord::Migration : ActiveRecord::Migration::Current) do
       define_method(:change, &block)
     end
   end


### PR DESCRIPTION
# Context

Gem itself is done in context that application has at least one enum.

If someone drops all postgres enum related things via migration and dumps the schema.rb, he will have 2 weird empty lines, which he would not have, if he had no gem.

So I've done this little request, so no empty lines would be added in schema.rb if there are no enums.