### PR TITLE
Fix error on rollback

### DIFF
--- a/lib/active_record/postgres_enum/command_recorder.rb
+++ b/lib/active_record/postgres_enum/command_recorder.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module PostgresEnum
     module CommandRecorder
-      def create_enum(name, values, _opts)
+      def create_enum(name, values, _opts = nil)
         record(:create_enum, [name, values])
       end
 

--- a/lib/active_record/postgres_enum/command_recorder.rb
+++ b/lib/active_record/postgres_enum/command_recorder.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module PostgresEnum
     module CommandRecorder
-      def create_enum(name, values)
+      def create_enum(name, values, _opts)
         record(:create_enum, [name, values])
       end
 

--- a/spec/active_record/migrations_spec.rb
+++ b/spec/active_record/migrations_spec.rb
@@ -5,8 +5,20 @@ require "spec_helper"
 RSpec.describe ActiveRecord::PostgresEnum::CommandRecorder do
   let(:connection) { ActiveRecord::Base.connection }
 
-  it "reverts create_enum" do
-    migration = build_migration { create_enum :genre, %w[drama comedy], if_not_exists: true }
+  it "reverts create_enum with no options" do
+    migration = build_migration { create_enum :genre, %w[drama comedy] }
+
+    migration.migrate(:up)
+
+    expect(connection.enum_types[:genre]).to eq %w[drama comedy]
+
+    migration.migrate(:down)
+
+    expect(connection.enum_types[:genre]).to be_nil
+  end
+
+  it "reverts create_enum with options" do
+    migration = build_migration { create_enum :genre, %w[drama comedy], force: true, if_not_exists: true }
 
     migration.migrate(:up)
 

--- a/spec/active_record/migrations_spec.rb
+++ b/spec/active_record/migrations_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ActiveRecord::PostgresEnum::CommandRecorder do
   let(:connection) { ActiveRecord::Base.connection }
 
   it "reverts create_enum" do
-    migration = build_migration { create_enum :genre, %w[drama comedy] }
+    migration = build_migration { create_enum :genre, %w[drama comedy], if_not_exists: true }
 
     migration.migrate(:up)
 


### PR DESCRIPTION
# Context

`#create_enum` allows for `if_not_exists` and `force` options
If no `down` migration is specifically created this will then cause an error on rollback
I was able to replicate this in a basic rails app with the following migration:
```
class EnumTest < ActiveRecord::Migration[7.1]
  def change
    create_enum :my_enum, %w[foo bar baz], if_not_exists: true
  end
end
```

```
➜ enum-test git:(main) ✗ rails db:rollback --trace                                                                                                                                                                                                                                                          [24-05-28|13:05:55]
** Invoke db:rollback (first_time)
** Invoke db:load_config (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute db:load_config
** Execute db:rollback
== 20240528043812 EnumTest: reverting =========================================
bin/rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

wrong number of arguments (given 3, expected 2)
/Users/enumlover42/.asdf/installs/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/activerecord-postgres_enum-2.0.1/lib/active_record/postgres_enum/command_recorder.rb:6:in `create_enum'
/Users/enumlover42/.asdf/installs/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/activerecord-7.1.3.3/lib/active_record/migration/default_strategy.rb:10:in `method_missing'
/Users/enumlover42/.asdf/installs/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/activerecord-7.1.3.3/lib/active_record/migration.rb:1047:in `block in method_missing'
/Users/enumlover42/.asdf/installs/ruby/3.1.4/lib/ruby/gems/3.1.0/gems/activerecord-7.1.3.3/lib/active_record/migration.rb:1017:in `block in say_with_time'
/Users/enumlover42/.asdf/installs/ruby/3.1.4/lib/ruby/3.1.0/benchmark.rb:296:in `measure'
```

## Related tickets



# What's inside

Adds an optional unused arg to `ActiveRecord::PostgresEnum::CommandRecorder`. This allows rollbacks to be handled gracefully when options are passed in

# Checklist:

- [x] I have added tests
- [ ] I have made corresponding changes to the documentation
