### PR TITLE
Fix working with separate schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ rename_enum_value :mood, "pensive", "wistful"
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
# Context

PostgreSQL allows working with multiple separate schemas and enum types can be present with the same name across them.

The gem is using the `pg_type` system catalog to access the different enum types, however this returns all enums from all existing schemas in the DB instead of just the currently selected ones, potentially leading to conflicts. This can be fixed by using the `current_schemas(true)` function which returns the schemas present in the current search path.

# What's inside

- Change the queries using `pg_type` to filter for the current schemas only
- Specs
- Readme update to run the specs as `rake spec` doesn't seem to work for me

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
